### PR TITLE
Standardize app naming, fix prompt formatting, and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# HTML Code Generator / HTMLコードジェネレーター
+# JavaScript Code Generator / JavaScriptコードジェネレーター
 
-An application that generates HTML code using ChatGPT API, with support for various animation libraries.
-ChatGPT APIを使用してHTMLコードを生成し、様々なアニメーションライブラリをサポートするアプリケーション。
+An application that generates HTML/JavaScript code using ChatGPT API, with support for various animation libraries.
+ChatGPT APIを使用してHTML/JavaScriptコードを生成し、様々なアニメーションライブラリをサポートするアプリケーション。
 
 ## Features / 機能
 

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Javascript Code Generator</title>
+    <title>JavaScript Code Generator</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="column left">
-        <header>Javascript Code Generator</header>
+        <header>JavaScript Code Generator</header>
         <div class="section-title">プロンプト</div>
         <textarea id="inputPrompt" placeholder="プロンプトを入力..."></textarea>
         <div class="button-group">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "code-generator",
+  "version": "1.0.0",
+  "description": "An application that generates HTML/JavaScript code using ChatGPT API, with support for various animation libraries. ChatGPT APIを使用してHTML/JavaScriptコードを生成し、様々なアニメーションライブラリをサポートするアプリケーション。",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/script.js
+++ b/script.js
@@ -72,17 +72,18 @@ async function sendRequest() {
 
     // 現在のコードをコンテキストとして含める
     const currentCode = outputArea.value;
-    const selectedLibraries = getSelectedLibraries();
-    const libraryInfo = selectedLibraries.length > 0 
-        ? `\n\n利用可能なライブラリ: ${selectedLibraries.join(', ')}` 
-        : '';
+      const selectedLibraries = getSelectedLibraries();
+      const libraryInfo = selectedLibraries.length > 0
+          ? `利用可能なライブラリ: ${selectedLibraries.join(', ')}`
+          : '';
+      const libraryInfoLine = libraryInfo ? `\n${libraryInfo}` : '';
 
-    let contextPrompt = prompt;
-    if (currentCode) {
-        contextPrompt = `現在のコード:\n\`\`\`html\n${currentCode}\n\`\`\`\n\n指示:\n${prompt}${libraryInfo}\n\n${promptSuffix}`;
-    } else {
-        contextPrompt = `${prompt}${libraryInfo}\n\n${promptSuffix}`;
-    }
+      let contextPrompt = prompt;
+      if (currentCode) {
+          contextPrompt = `現在のコード:\n\`\`\`html\n${currentCode}\n\`\`\`\n\n指示:\n${prompt}${libraryInfoLine}\n\n${promptSuffix}`;
+      } else {
+          contextPrompt = `${prompt}${libraryInfoLine}\n\n${promptSuffix}`;
+      }
 
     // デバッグ用：プロンプトの内容を確認
     console.log('送信するプロンプト:', contextPrompt);
@@ -211,3 +212,8 @@ window.addEventListener('load', () => {
     promptSuffix = promptSuffixInput.value;
     console.log('初期化時のpromptSuffix:', promptSuffix);
 });
+
+// Export functions for testing environments
+if (typeof module !== 'undefined') {
+    module.exports = { getSelectedLibraries, getLibraryUrls };
+}

--- a/script.test.js
+++ b/script.test.js
@@ -1,0 +1,36 @@
+const { getSelectedLibraries, getLibraryUrls } = require('./script.js');
+
+describe('getSelectedLibraries', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="useThreeJs">
+      <input type="checkbox" id="useAnimeJs">
+      <input type="checkbox" id="useGsap">
+      <input type="checkbox" id="useP5">
+    `;
+  });
+
+  test('returns empty array when no libraries selected', () => {
+    expect(getSelectedLibraries()).toEqual([]);
+  });
+
+  test('returns selected libraries', () => {
+    document.getElementById('useThreeJs').checked = true;
+    document.getElementById('useP5').checked = true;
+    expect(getSelectedLibraries()).toEqual(['three.js', 'p5.js']);
+  });
+});
+
+describe('getLibraryUrls', () => {
+  test('returns URLs for selected libraries', () => {
+    const urls = getLibraryUrls(['three.js', 'anime.js']);
+    expect(urls).toEqual([
+      'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js'
+    ]);
+  });
+
+  test('ignores unknown libraries', () => {
+    expect(getLibraryUrls(['unknown'])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Rename interface elements and documentation to "JavaScript Code Generator" for consistent branding
- Separate user prompt and library info with newlines and expose functions for testing
- Add Jest-based unit tests and project configuration

## Testing
- `npm install --save-dev jest` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b56b6f5d708327a5cbece411263520